### PR TITLE
Fix Build Constraints

### DIFF
--- a/scard_unix.go
+++ b/scard_unix.go
@@ -1,4 +1,4 @@
-// +build !windows, !darwin
+// +build !windows,!darwin
 
 package scard
 


### PR DESCRIPTION
It seems the space has particular meaning as build constraints
So windows will try to build scard_unix.go...
Thanks.