### PR TITLE
fix MAX_READERNAME for OSX

### DIFF
--- a/scard_darwin.go
+++ b/scard_darwin.go
@@ -90,8 +90,9 @@ func scardEndTransaction(card uintptr, disp Disposition) Error {
 	return Error(r)
 }
 
+const MAX_READERNAME = 128
 func scardCardStatus(card uintptr) (string, State, Protocol, []byte, Error) {
-	var readerBuf [C.MAX_READERNAME + 1]byte
+	var readerBuf [MAX_READERNAME + 1]byte
 	var readerLen = C.uint32_t(len(readerBuf))
 	var state, proto C.uint32_t
 	var atr [maxAtrSize]byte


### PR DESCRIPTION
OSX has weired issue. MAX_READERNAME is defined by 53.

~~~
grep MAX_READERNAME /System/Library/Frameworks/PCSC.framework/Versions/A/Headers/pcsclite.h 
#define MAX_READERNAME			52
~~~

And SCardStatus() will always fail with long name reader.
I've confirmed on OSX 10.13.3 High Sierra.
I propose to use 128 in the same as unix.