### PR TITLE
Add Card.ActiveProtocol accessor

### DIFF
--- a/scard.go
+++ b/scard.go
@@ -140,6 +140,11 @@ func (ctx *Context) Connect(reader string, mode ShareMode, proto Protocol) (*Car
 	return &Card{handle: handle, activeProtocol: activeProtocol}, nil
 }
 
+// the protocol being used
+func (card *Card) ActiveProtocol() Protocol {
+	return card.activeProtocol
+}
+
 // wraps SCardDisconnect
 func (card *Card) Disconnect(d Disposition) error {
 	r := scardDisconnect(card.handle, d)


### PR DESCRIPTION
This piece of information is useful for some things (such as whether GET
RESPONSE APDUs are needed and such).

The active protocol can already be obtained with Card.Status(), however
we already have it stashed in the struct (returned by SCardConnect()),
so add a getter to make it slightly faster and error-free.