### PR TITLE
Add equivalent for C macro SCARD_CTL_CODE()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ebfe/scard
+
+go 1.19

--- a/scard.go
+++ b/scard.go
@@ -218,6 +218,11 @@ func (card *Card) Transmit(cmd []byte) ([]byte, error) {
 	return rsp[:rspLen], nil
 }
 
+// C macro SCARD_CTL_CODE() equivalent to Compute IOCTL codes to be used with Control()
+func CtlCode(code uint16) uint32 {
+	return 0x42000000 + uint32(code)
+}
+
 // wraps SCardControl
 func (card *Card) Control(ioctl uint32, in []byte) ([]byte, error) {
 	var out [0xffff]byte


### PR DESCRIPTION
When using `Control(ioctl uint32, in []byte)` the `ioctl` code must be set using the macro [SCARD_CTL_CODE()](https://pcsclite.apdu.fr/api/reader_8h.html#a77839183c3ae7b0cea39fbaff9f9aabb).

This PR Add a function to replace this missing macro. It also add the missing `go.mod` file.
