### PR TITLE
[scard] Fix CtlCode() to match winscard definition

### DIFF
--- a/scard.go
+++ b/scard.go
@@ -220,7 +220,7 @@ func (card *Card) Transmit(cmd []byte) ([]byte, error) {
 
 // C macro SCARD_CTL_CODE() equivalent to Compute IOCTL codes to be used with Control()
 func CtlCode(code uint16) uint32 {
-	return 0x42000000 + uint32(code)
+	return 0x310000 | (uint32(code) << 2)
 }
 
 // wraps SCardControl


### PR DESCRIPTION
Under windows in the winscard API the macro `SDCARD_CTL_CODE()` is not defined as in the Linux port (as defined in my previous PR #19.

This new PR make the `CtlCode()` function to works Linux **AND** windows.

Sorry for the previous PR which works only for Linux.
