### PR TITLE
feat: removed panic from darwin read error

### DIFF
--- a/scard_darwin.go
+++ b/scard_darwin.go
@@ -124,7 +124,7 @@ func scardTransmit(card uintptr, proto Protocol, cmd []byte, rsp []byte) (uint32
 	case ProtocolT0, ProtocolT1:
 		sendpci.dwProtocol = C.uint32_t(proto)
 	default:
-		panic("unknown protocol")
+		return 0, Error(C.SCARD_F_INTERNAL_ERROR)
 	}
 	sendpci.cbPciLength = C.sizeof_SCARD_IO_REQUEST
 


### PR DESCRIPTION
Darwin would panic if `scardTransmit` failed. This would occur during partial reads, such as if someone removes the card too quickly during a tap, resulting in applications implementing this to panic. This is undesired behaviour. I've amended this to return `SCARD_F_INTERNAL_ERROR` from PCSC instead, which I think is suitable. 

Please let me know if there are any other suggestions to remediate this