### PR TITLE
add a mutex to avoid concurrent map writes

### DIFF
--- a/scard_darwin.go
+++ b/scard_darwin.go
@@ -10,6 +10,7 @@ package scard
 import "C"
 
 import (
+	"sync"
 	"unsafe"
 )
 
@@ -192,6 +193,7 @@ type scardReaderState struct {
 }
 
 var pinned = map[string]*strbuf{}
+var mutex sync.Mutex
 
 func (rs *ReaderState) toSys() (scardReaderState, error) {
 	var sys scardReaderState
@@ -200,7 +202,11 @@ func (rs *ReaderState) toSys() (scardReaderState, error) {
 	if err != nil {
 		return scardReaderState{}, err
 	}
+
+	mutex.Lock()
 	pinned[rs.Reader] = &creader
+	mutex.Unlock()
+
 	sys.szReader = uintptr(creader.ptr())
 	sys.dwCurrentState = uint32(rs.CurrentState)
 	sys.cbAtr = uint32(len(rs.Atr))

--- a/scard_unix.go
+++ b/scard_unix.go
@@ -14,6 +14,7 @@ package scard
 import "C"
 
 import (
+	"sync"
 	"unsafe"
 )
 
@@ -185,6 +186,7 @@ type scardReaderState struct {
 }
 
 var pinned = map[string]*strbuf{}
+var mutex sync.Mutex
 
 func (rs *ReaderState) toSys() (scardReaderState, error) {
 	var sys scardReaderState
@@ -193,7 +195,11 @@ func (rs *ReaderState) toSys() (scardReaderState, error) {
 	if err != nil {
 		return scardReaderState{}, err
 	}
+
+	mutex.Lock()
 	pinned[rs.Reader] = &creader
+	mutex.Unlock()
+
 	sys.szReader = uintptr(creader.ptr())
 	sys.dwCurrentState = uintptr(rs.CurrentState)
 	sys.cbAtr = uintptr(len(rs.Atr))


### PR DESCRIPTION
plugging/unplugging the smartcard reader when invoking `GetStatusChange` could cause `fatal error: concurrent map read and map` due to concurrent access to the `pinned` map. This PR solves the issue by adding a mutex to access said map